### PR TITLE
feat(ci): add LoongArch64 testing with QEMU user-mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,8 +96,7 @@ jobs:
           QEMU_LD_PREFIX: /usr/riscv64-linux-gnu
           OBJDUMP: /usr/bin/riscv64-linux-gnu-objdump
           CLANG: /usr/bin/clang
-        run: |
-          qemu-riscv64-static ./goat tests/src/universal.c -o tests -march=rv64imafd
+        run: qemu-riscv64-static ./goat tests/src/universal.c -o tests -march=rv64imafd
       - name: Run tests with QEMU
         env:
           QEMU_LD_PREFIX: /usr/riscv64-linux-gnu
@@ -105,3 +104,31 @@ jobs:
           cd tests
           GOOS=linux GOARCH=riscv64 CGO_ENABLED=0 go test -c -o tests.test
           qemu-riscv64-static ./tests.test -test.v
+
+  loong64:
+    name: qemu-loong64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+      - name: Install dependencies
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: qemu-user-static clang lld binutils-loongarch64-linux-gnu gcc-14-loongarch64-linux-gnu g++-14-loongarch64-linux-gnu
+      - name: Cross-compile GOAT for LoongArch
+        run: GOOS=linux GOARCH=loong64 CGO_ENABLED=0 go build -o goat .
+      - name: Generate LoongArch assembly with GOAT
+        env:
+          CC: loongarch64-linux-gnu-gcc-14
+          CXX: loongarch64-linux-gnu-g++-14
+          QEMU_LD_PREFIX: /usr/loongarch64-linux-gnu
+          OBJDUMP: /usr/bin/loongarch64-linux-gnu-objdump
+          CLANG: /usr/bin/clang
+        run: qemu-loongarch64-static ./goat tests/src/universal.c -o tests
+      - name: Run tests with QEMU
+        env:
+          QEMU_LD_PREFIX: /usr/loongarch64-linux-gnu
+        run: |
+          cd tests
+          GOOS=linux GOARCH=loong64 CGO_ENABLED=0 go test -c -o tests.test
+          qemu-loongarch64-static ./tests.test -test.v


### PR DESCRIPTION
Add LoongArch64 (loong64) CI testing using QEMU user-mode emulation.

## Changes

- Add `loong64` job to test matrix
- Download LoongArch cross-compiler from Loongson official release
- Cross-compile GOAT for loong64 architecture
- Run tests via `qemu-loongarch64-static` user-mode emulation

## Similar to RISC-V

This follows the same pattern as the RISC-V testing (PR #57):
- Cross-compile GOAT binary for the target architecture
- Use QEMU user-mode emulation to run tests
- No full VM or container needed

## Cross-compiler source

Using Loongson's official cross-tools release: https://github.com/loongson/build-tools/releases